### PR TITLE
Fixed issue (#15) - App crashes while opening some Heritage Sites

### DIFF
--- a/app/src/main/java/com/rajit/worldheritages/MainActivity.kt
+++ b/app/src/main/java/com/rajit/worldheritages/MainActivity.kt
@@ -43,22 +43,20 @@ import androidx.compose.ui.unit.dp
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
-import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navArgument
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.rajit.worldheritages.data.model.HeritageEntity
 import com.rajit.worldheritages.data.model.toFavouriteEntity
+import com.rajit.worldheritages.data.model.toHeritageEntity
 import com.rajit.worldheritages.ui.components.HeritageDetailScreen
 import com.rajit.worldheritages.ui.components.HeritageListView
 import com.rajit.worldheritages.ui.components.MyBottomSheet
 import com.rajit.worldheritages.ui.screen.FavouritesScreen
 import com.rajit.worldheritages.ui.screen.SearchScreen
 import com.rajit.worldheritages.ui.theme.WorldHeritagesTheme
-import com.rajit.worldheritages.util.Constants
 import com.rajit.worldheritages.viewmodel.MainViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -265,6 +263,7 @@ fun MyNavigation(
     navController: NavHostController,
     mainViewModel: MainViewModel = koinViewModel()
 ) {
+
     Box(modifier = Modifier.padding(contentPadding)) {
         NavHost(navController = navController, startDestination = "main") {
 
@@ -275,25 +274,20 @@ fun MyNavigation(
                     countryTagPrefState.value,
                     onListItemClicked = {
 
-                        // This is done because Navigation Component can't directly use URL as argument
-                        // We need to encode the URL before passing it as argument
-                        // Decoding is taken care of by Compose-Navigation
-                        val encodedPageURL = Constants.encodeURLForNavigation(it.page)
-                        val encodedImageURL = Constants.encodeURLForNavigation(it.image)
+                        // Setting the HeritageEntity in MainViewModel for HeritageDetail Screen to retrieve
+                        mainViewModel.heritageDetailState.value = it
 
-                        // This is done because Navigation Component can't directly use multiline string as argument
-                        // We need to encode the multiline string before passing it as argument
-                        val formattedShortInfo = Constants.encodeMultiLineString(it.shortInfo)
-                        val formattedLongInfo = if (it.longInfo.isNullOrEmpty()) {
-                            "Not Available"
-                        } else {
-                            Constants.encodeMultiLineString(it.longInfo.trim())
-                        }
+                        navController.navigate(route = "detail")
 
-                        navController.navigate(
-                            route = "detail/${it.id}/${it.year}/${it.target}/${it.name}/${it.type}/${it.region}/${it.regionLong}/${it.coordinates}/${it.lat}/${it.lng}/$encodedPageURL/$encodedImageURL/${it.imageAuthor}/${formattedShortInfo}/$formattedLongInfo"
-                        )
+//                        // This is done because Navigation Component can't directly use URL as argument
+//                        // We need to encode the URL before passing it as argument
+//                        // Decoding is taken care of by Compose-Navigation
+//                        val encodedPageURL = Constants.encodeURLForNavigation(it.page)
+//                        val encodedImageURL = Constants.encodeURLForNavigation(it.image)
 
+//                        navController.navigate(
+//                            route = "detail/${it.id}/${it.year}/${it.target}/${it.name}/${it.type}/${it.region}/${it.regionLong}/${it.coordinates}/${it.lat}/${it.lng}/$encodedPageURL/$encodedImageURL/${it.imageAuthor}/${formattedShortInfo}/$formattedLongInfo"
+//                        )
                     }
                 )
             }
@@ -302,24 +296,12 @@ fun MyNavigation(
             composable(route = "search") {
                 SearchScreen(
                     onItemClicked = {
-                        // This is done because Navigation Component can't directly use URL as argument
-                        // We need to encode the URL before passing it as argument
-                        // Decoding is taken care of by Compose-Navigation
-                        val encodedPageURL = Constants.encodeURLForNavigation(it.page)
-                        val encodedImageURL = Constants.encodeURLForNavigation(it.image)
 
-                        // This is done because Navigation Component can't directly use multiline string as argument
-                        // We need to encode the multiline string before passing it as argument
-                        val formattedShortInfo = Constants.encodeMultiLineString(it.shortInfo)
-                        val formattedLongInfo = if (it.longInfo.isNullOrEmpty()) {
-                            "Not Available"
-                        } else {
-                            Constants.encodeMultiLineString(it.longInfo.trim())
-                        }
+                        // Setting the HeritageEntity in MainViewModel for HeritageDetail Screen to retrieve
+                        mainViewModel.heritageDetailState.value = it
 
-                        navController.navigate(
-                            route = "detail/${it.id}/${it.year}/${it.target}/${it.name}/${it.type}/${it.region}/${it.regionLong}/${it.coordinates}/${it.lat}/${it.lng}/$encodedPageURL/$encodedImageURL/${it.imageAuthor}/${formattedShortInfo}/$formattedLongInfo"
-                        )
+                        navController.navigate(route = "detail")
+
                     }
                 )
             }
@@ -328,170 +310,52 @@ fun MyNavigation(
             composable(route = "favourites") {
                 FavouritesScreen(
                     onItemClicked = {
-                        // This is done because Navigation Component can't directly use URL as argument
-                        // We need to encode the URL before passing it as argument
-                        // Decoding is taken care of by Compose-Navigation
-                        val encodedPageURL = Constants.encodeURLForNavigation(it.page)
-                        val encodedImageURL = Constants.encodeURLForNavigation(it.image)
 
-                        // This is done because Navigation Component can't directly use multiline string as argument
-                        // We need to encode the multiline string before passing it as argument
-                        val formattedShortInfo = Constants.encodeMultiLineString(it.shortInfo)
-                        val formattedLongInfo = if (it.longInfo.isNullOrEmpty()) {
-                            "Not Available"
-                        } else {
-                            Constants.encodeMultiLineString(it.longInfo.trim())
-                        }
+                        // Converting FavouriteEntity to HeritageEntity
+                        val heritage = it.toHeritageEntity()
 
-                        navController.navigate(
-                            route = "detail/${it.id}/${it.year}/${it.target}/${it.name}/${it.type}/${it.region}/${it.regionLong}/${it.coordinates}/${it.lat}/${it.lng}/$encodedPageURL/$encodedImageURL/${it.imageAuthor}/${formattedShortInfo}/$formattedLongInfo"
-                        )
+                        // Setting the HeritageEntity in MainViewModel for HeritageDetail Screen to retrieve
+                        mainViewModel.heritageDetailState.value = heritage
+
+                        navController.navigate(route = "detail")
                     },
                     onItemLongClicked = { mainViewModel.deleteFavourite(it) }
                 )
             }
 
-            composable(
-                route = "detail/{heritageID}/{heritageYear}/{heritageTarget}/{heritageName}/{heritageType}/{heritageRegion}/{heritageRegionLong}/{heritageCoordinates}/{heritageLat}/{heritageLng}/{heritagePage}/{heritageImageURL}/{heritageImageAuthor}/{heritageShortInfo}/{heritageLongInfo}",
-                arguments = listOf(
+            // Heritage Detail Screen
+            composable(route = "detail") {
 
-                    // Heritage ID
-                    navArgument("heritageID") {
-                        type = NavType.IntType
-                    },
-
-                    // Heritage Year
-                    navArgument("heritageYear") {
-                        type = NavType.IntType
-                    },
-
-                    // Heritage Target - Country
-                    navArgument("heritageTarget") {
-                        type = NavType.StringType
-                    },
-
-                    // Heritage Name
-                    navArgument("heritageName") {
-                        type = NavType.StringType
-                    },
-
-                    // Heritage Tag
-                    navArgument("heritageType") {
-                        type = NavType.StringType
-                    },
-
-                    // Heritage Region
-                    navArgument("heritageRegion") {
-                        type = NavType.StringType
-                    },
-
-                    // Heritage RegionLong
-                    navArgument("heritageRegionLong") {
-                        type = NavType.StringType
-                    },
-
-                    // Heritage Coordinates
-                    navArgument("heritageCoordinates") {
-                        type = NavType.StringType
-                    },
-
-                    // Heritage Latitude
-                    navArgument("heritageLat") {
-                        type = NavType.StringType
-                    },
-
-                    // Heritage Longitude
-                    navArgument("heritageLng") {
-                        type = NavType.StringType
-                    },
-
-                    // Heritage Page Link
-                    navArgument("heritagePage") {
-                        type = NavType.StringType
-                    },
-
-                    // Heritage Image URL
-                    navArgument("heritageImageURL") {
-                        type = NavType.StringType
-                    },
-
-                    // Heritage Image Author
-                    navArgument("heritageImageAuthor") {
-                        type = NavType.StringType
-                    },
-
-                    // Heritage Short Info
-                    navArgument("heritageShortInfo") {
-                        type = NavType.StringType
-                    },
-
-                    // Heritage Long Info
-                    navArgument("heritageLongInfo") {
-                        type = NavType.StringType
-                    }
-
-                )
-            ) { navBackStackEntry ->
-
-                val heritageID = navBackStackEntry.arguments?.getInt("heritageID")
-                val heritageYear = navBackStackEntry.arguments?.getInt("heritageYear")
-                val heritageTarget = navBackStackEntry.arguments?.getString("heritageTarget")
-                val heritageName = navBackStackEntry.arguments?.getString("heritageName")
-                val heritageType = navBackStackEntry.arguments?.getString("heritageType")
-                val heritageRegion = navBackStackEntry.arguments?.getString("heritageRegion")
-                val heritageRegionLong =
-                    navBackStackEntry.arguments?.getString("heritageRegionLong")
-                val heritageCoordinates =
-                    navBackStackEntry.arguments?.getString("heritageCoordinates")
-                val heritageLat = navBackStackEntry.arguments?.getString("heritageLat")
-                val heritageLng = navBackStackEntry.arguments?.getString("heritageLng")
-                val heritagePage = navBackStackEntry.arguments?.getString("heritagePage")
-                val heritageImageURL = navBackStackEntry.arguments?.getString("heritageImageURL")
-                val heritageImageAuthor =
-                    navBackStackEntry.arguments?.getString("heritageImageAuthor")
-                val heritageShortInfo = navBackStackEntry.arguments?.getString("heritageShortInfo")
-                val heritageLongInfo = navBackStackEntry.arguments?.getString("heritageLongInfo")
-
-                val heritageEntity = HeritageEntity(
-                    heritageID!!,
-                    heritageYear!!,
-                    heritageTarget!!,
-                    heritageName!!,
-                    heritageType!!,
-                    heritageRegion!!,
-                    heritageRegionLong!!,
-                    heritageCoordinates!!,
-                    heritageLat!!.toDouble(),
-                    heritageLng!!.toDouble(),
-                    heritagePage!!,
-                    heritageImageURL!!,
-                    heritageImageAuthor!!,
-                    Constants.decodeMultilineString(heritageShortInfo!!), // Since Compose decoding is not decoding multiline properly so we do it manually
-                    Constants.decodeMultilineString(heritageLongInfo!!) // Since Compose decoding is not decoding multiline properly so we do it manually
-                )
+                var heritage by remember {
+                    mutableStateOf<HeritageEntity?>(null)
+                }
 
                 var isFavorite by remember { mutableStateOf(false) }
 
                 LaunchedEffect(key1 = Unit) {
                     withContext(Dispatchers.IO) {
-                        isFavorite = mainViewModel.fetchFavouriteByID(heritageEntity.id)
+                        heritage = mainViewModel.heritageDetailState.value
+                        if (heritage != null) {
+                            isFavorite = mainViewModel.fetchFavouriteByID(heritage!!.id)
+                        }
                     }
                 }
 
-                HeritageDetailScreen(
-                    isFavourite = isFavorite,
-                    heritage = heritageEntity,
-                    onFabClicked = {
-                        if (it) { // If Already Bookmarked, Delete Favourite
-                            mainViewModel.deleteFavourite(heritageEntity.toFavouriteEntity())
-                        } else { // Otherwise Save to Favourites
-                            mainViewModel.saveToFavourites(heritageEntity.toFavouriteEntity())
+                if (heritage != null) {
+                    HeritageDetailScreen(
+                        isFavourite = isFavorite,
+                        heritage = heritage!!,
+                        onFabClicked = {
+                            if (it) { // If Already Bookmarked, Delete Favourite
+                                mainViewModel.deleteFavourite(heritage!!.toFavouriteEntity())
+                            } else { // Otherwise Save to Favourites
+                                mainViewModel.saveToFavourites(heritage!!.toFavouriteEntity())
+                            }
                         }
-                    }
-                )
+                    )
+                }
 
             }
-
         }
     }
 }

--- a/app/src/main/java/com/rajit/worldheritages/data/model/FavouriteEntity.kt
+++ b/app/src/main/java/com/rajit/worldheritages/data/model/FavouriteEntity.kt
@@ -23,3 +23,21 @@ data class FavouriteEntity(
     val shortInfo: String,
     val longInfo: String?
 )
+
+fun FavouriteEntity.toHeritageEntity() = HeritageEntity(
+    id,
+    year,
+    target,
+    name,
+    type,
+    region,
+    regionLong,
+    coordinates,
+    lat,
+    lng,
+    page,
+    image,
+    imageAuthor,
+    shortInfo,
+    longInfo
+)

--- a/app/src/main/java/com/rajit/worldheritages/util/Constants.kt
+++ b/app/src/main/java/com/rajit/worldheritages/util/Constants.kt
@@ -1,7 +1,6 @@
 package com.rajit.worldheritages.util
 
 import android.net.Uri
-import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
@@ -19,7 +18,7 @@ object Constants {
     const val DEFAULT_COUNTRY_FILTER = "ALL"
     const val DEFAULT_TAG_FILTER = "All"
 
-    val countryList = listOf<String>(
+    val countryList = listOf(
         "ALL",
         "AFG",
         "ALB",
@@ -182,7 +181,7 @@ object Constants {
         "ZWE"
     )
 
-    val tagList = listOf<String>(
+    val tagList = listOf(
         "All",
         "Cultural",
         "Mixed",
@@ -365,19 +364,6 @@ object Constants {
     // Decoding of this encoded URL is taken care of by Compose-Navigation
     fun encodeURLForNavigation(url: String): String {
         return URLEncoder.encode(url, StandardCharsets.UTF_8.toString())
-    }
-
-    // Compose-Navigation can't directly use Multiline String in its navigation arguments
-    // So, we encode the Multiline String and then pass it as navArgument
-    // Decoding of this encoded Multiline String is taken care of by Compose-Navigation
-    fun encodeMultiLineString(multilineString: String): String {
-        return URLEncoder.encode(multilineString, StandardCharsets.UTF_8.toString())
-    }
-
-    // Compose-Navigation is decoding Multiline String abnormally
-    // So we are doing it ourselves
-    fun decodeMultilineString(multilineString: String): String {
-        return URLDecoder.decode(multilineString, StandardCharsets.UTF_8.toString())
     }
 
     // This converts the supplied Latitude and Longitude values to Geo URI

--- a/app/src/main/java/com/rajit/worldheritages/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/rajit/worldheritages/viewmodel/MainViewModel.kt
@@ -21,6 +21,9 @@ class MainViewModel(
     private var _countryTagPrefState: MutableStateFlow<Pair<String, String>> = MutableStateFlow(Pair("ALL", "All"))
     val countryTagPref: StateFlow<Pair<String, String>> get()= _countryTagPrefState
 
+    // Used for Sending Heritage Data to Heritage Detail Screen
+    var heritageDetailState: MutableStateFlow<HeritageEntity?> = MutableStateFlow(null)
+
     init {
         getCountryAndTagPreference()
     }


### PR DESCRIPTION
Fixed issue (#15) - App crashes while opening them in Heritage Detail Screen for some heritage sites. Especially the Indian heritage sites. Removed the navArguments and used MutableStateFlow inside a SharedViewModel to show heritage details.